### PR TITLE
fix reference to defunct website

### DIFF
--- a/STM32/package_stm_index.json
+++ b/STM32/package_stm_index.json
@@ -6,7 +6,7 @@
       "maintainer": "STMicroelectronics",
       "email": "",
       "help": {
-        "online": "http://www.stm32duino.com/"
+        "online": "https://github.com/stm32duino/"
       },
       "platforms": [
         {


### PR DESCRIPTION
now points to github